### PR TITLE
bugfix: handle paths in subscriptions

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -21,7 +21,7 @@ const (
 type SubscriptionMsg struct {
 	Host   string `json:"host,omitempty"` //aka collector
 	Peer   string `json:"peer,omitempty"`
-	Asn    int    `json:"asn,omitempty"`
+	Path   string `json:"path,omitempty"`
 	Prefix string `json:"prefix,omitempty"`
 }
 

--- a/src/parse/ris_live.go
+++ b/src/parse/ris_live.go
@@ -25,7 +25,7 @@ var interrupt chan os.Signal
 type RisMessageData struct {
 	Host   string `json:"host,omitempty"` //aka collector
 	Peer   string `json:"peer,omitempty"`
-	Asn    int    `json:"asn,omitempty"` //aka ASN
+	Path   string `json:"path,omitempty"` //aka ASN
 	Prefix string `json:"prefix,omitempty"`
 }
 
@@ -108,7 +108,7 @@ func handleSubscription(msgChannel chan common.Message, subscription config.Subs
 	fmt.Println("made connection")
 
 	//subscribe
-	sub := RisMessage{"ris_subscribe", &RisMessageData{subscription.Host, subscription.Peer, subscription.Asn, subscription.Prefix}}
+	sub := RisMessage{"ris_subscribe", &RisMessageData{subscription.Host, subscription.Peer, subscription.Path, subscription.Prefix}}
 	out, err := json.Marshal(sub)
 	if err != nil {
 		return errors.New("Error marshalling subscription message, " + err.Error())


### PR DESCRIPTION
The "path" filter in `ris_subscribe` is where we can filter for ASNs, but it got dropped between the config and the actual subscription leading to actually subscribing to the full feed.

This is a tiny fix to pass "path" filters around.